### PR TITLE
Increase locker storage from 500L to 2000L

### DIFF
--- a/data/json/furniture.json
+++ b/data/json/furniture.json
@@ -1356,7 +1356,7 @@
         { "item": "pipe", "count": [ 4, 8 ] }
       ]
     },
-    "max_volume": 2000,
+    "max_volume": 8000,
     "bash": {
       "str_min": 12,
       "str_max": 40,


### PR DESCRIPTION
 

<!--
### How to use
Leave the headings unless they don't apply to your PR, replace commented out text (surrounded with <!–– and ––>) with text describing your PR.
-->

#### Summary
<!--
A one-line description of your change that will be extracted and added to the [project changelog](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/data/changelog.txt).

The format is (ignore the square brackets): ```SUMMARY: [Category] "[description]"```

The categories to choose from are:

* Features
* Content
* Interface
* Mods
* Balance
* Bugfixes
* Performance
* Infrastructure
* Build
* I18N

Example: ```SUMMARY: Content "Adds new mutation category 'Mouse'"```

See the [Changelog Guidelines](https://github.com/CleverRaven/Cataclysm-DDA/blob/master/doc/CHANGELOG_GUIDELINES.md) for explanations of the categories.
-->
SUMMARY: Balance/Bugfixes "Change locker storage volume to be in line with other furniture options"
#### Purpose of change
<!--
If there's an existing issue describing the problem this PR addresses or the feature it adds, please link it like: ```#1234```
If it *fully* resolves an issue, link it like: ```Fixes #1234```
Even if the issue describes the problem, please provide a few-sentence summary here.
Example: ```Fixes #1234 - XL mutants cannot wear arm/leg splints due to missing OVERSIZE flag.```
If there is no related issue, please describe the issue you are addressing, including how to trigger a bug if this is a bugfix.
Don't put the backticks around the `#` and issue or pull request number to allow the GitHub automatically reference to it.
-->
Lockers currently have less storage volume than a floor tile, making them worse than useless as storage furniture.

#### Describe the solution
<!--
How does the feature work, or how does this fix a bug?
The easier you make your solution to understand, the faster it can get merged.
-->
The only change is in furniture.json, changing the locker's "max_volume" from 2000 to 8000. I'm assuming the current storage volume is a bug, as it's half of an empty tile, and dressers have 2000L. Most likely somebody forgot/didn't realize that 1 unit = 0.25L, so they put 2000 instead of 8000. If this is not the case, and lockers are really supposed to have 500L of storage, then ignore this PR.

#### Describe alternatives you've considered
<!--
A clear and concise description of any alternative solutions or features you've considered.
-->
It's a very small change so I haven't really considered any alternatives. Unless you count just manually editing my own JSON every update which is what I've been doing.

#### Additional context
<!--
Add any other context (such as mock-ups, proof of concepts or screenshots) about the feature or bugfix here.
-->
This is my first time using GitHub so if I did something wrong sorry!
